### PR TITLE
cheesecacke_index.py: Code beautification to be more PEP8 conform

### DIFF
--- a/cheesecake/cheesecake_index.py
+++ b/cheesecake/cheesecake_index.py
@@ -1227,8 +1227,8 @@ class IndexPyLint(Index):
     def _pylint_args(cls):
         try:
             import pylint.__pkginfo__
-            version = map(int, pylint.__pkginfo__.version.split('.'))
-            if version > (0, 21):
+            from distutils.version import LooseVersion
+            if LooseVersion(pylint.__pkginfo__.version) > LooseVersion("0.21"):
                 disable_option = "disable-msg"
             else:
                 disable_option = "disable"


### PR DESCRIPTION
cheesecacke_index.py is not completely PEP8 conform, because in some places it would have reduced readability. But it is much more PEP8 conform now and hopefully easier to read.
